### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"         : "6.c",
     "name"         : "Bailador::Plugin::Static",
+    "license"      : "Artistic-2.0",
     "version"      : "3.001001",
     "description"  : "Automatically serve static files",
     "depends"      : [ "Bailador", "MIME::Types" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license